### PR TITLE
Add lat/lng to FavoriteStopViewModel

### DIFF
--- a/CorvallisBus.Core/Models/FavoriteStop.cs
+++ b/CorvallisBus.Core/Models/FavoriteStop.cs
@@ -7,19 +7,23 @@ namespace CorvallisBus.Core.Models
 {
     public class FavoriteStop
     {
-        public FavoriteStop(int id, string name, List<string> routeNames, double distanceFromUser, bool isNearestStop)
+        public FavoriteStop(int id, string name, List<string> routeNames, double lat, double lng, double distanceFromUser, bool isNearestStop)
         {
             Id = id;
             Name = name;
             RouteNames = routeNames;
+            Lat = lat;
+            Long = lng;
             DistanceFromUser = distanceFromUser;
             IsNearestStop = isNearestStop;
         }
 
-        public int Id { get; private set; }
-        public string Name { get; private set; }
-        public List<string> RouteNames { get; private set; }
-        public double DistanceFromUser { get; private set; }
-        public bool IsNearestStop { get; private set; }
+        public int Id { get; }
+        public string Name { get; }
+        public List<string> RouteNames { get; }
+        public double Lat { get; }
+        public double Long { get; }
+        public double DistanceFromUser { get; }
+        public bool IsNearestStop { get; }
     }
 }

--- a/CorvallisBus.Core/Models/FavoriteStopViewModel.cs
+++ b/CorvallisBus.Core/Models/FavoriteStopViewModel.cs
@@ -17,6 +17,18 @@ namespace CorvallisBus.Core.Models
         [JsonProperty("stopID")]
         public int StopId { get; set; }
 
+        /// <summary>
+        /// The latitude value for the stop (between -90 and 90 degrees).
+        /// </summary>
+        [JsonProperty("lat")]
+        public double Lat { get; set; }
+
+        /// <summary>
+        /// The longitude value for the stop (between -180 and 180 degrees).
+        /// </summary>
+        [JsonProperty("lng")]
+        public double Long { get; set; }
+
         [JsonProperty("distanceFromUser")]
         public string DistanceFromUser { get; set; }
 

--- a/CorvallisBus.Core/TransitManager.cs
+++ b/CorvallisBus.Core/TransitManager.cs
@@ -140,7 +140,7 @@ namespace CorvallisBus
                         ? DistanceTo(optionalUserLocation.Value.Lat, optionalUserLocation.Value.Lon, stop.Lat, stop.Long, 'M')
                         : double.NaN;
 
-                return new FavoriteStop(stop.ID, stop.Name, stop.RouteNames, distanceFromUser, isNearestStop: false);
+                return new FavoriteStop(stop.ID, stop.Name, stop.RouteNames, stop.Lat, stop.Long, distanceFromUser, isNearestStop: false);
             })
             .ToList();
 
@@ -158,6 +158,7 @@ namespace CorvallisBus
                     : double.NaN;
 
                 favoriteStops.Add(new FavoriteStop(nearestStop.ID, nearestStop.Name, nearestStop.RouteNames,
+                                                   nearestStop.Lat, nearestStop.Long,
                                                    distanceFromUser, isNearestStop: true));
             }
 
@@ -191,6 +192,9 @@ namespace CorvallisBus
                 SecondRouteName = secondRoute != null ? secondRoute.RouteNo : string.Empty,
                 SecondRouteColor = secondRoute != null ? secondRoute.Color : string.Empty,
                 SecondRouteArrivals = routeSchedules.Count > 1 ? RouteArrivalsSummary.ToEstimateSummary(routeSchedules[1].Value, currentTime) : string.Empty,
+
+                Lat = favorite.Lat,
+                Long = favorite.Long,
 
                 DistanceFromUser = double.IsNaN(favorite.DistanceFromUser) ? "" : $"{favorite.DistanceFromUser:F1} miles",
                 IsNearestStop = favorite.IsNearestStop


### PR DESCRIPTION
Addresses #16.
@ZacharyKhan you can play around with this now using https://corvallisbus.azurewebsites.net. 

Sample URL for your convenience:
https://corvallisbus.azurewebsites.net/api/favorites?stops=11776,10308&location=44.5645659,-123.2620435

Will be changing corvallisb.us to point here soon. Probably on Sunday just so that if I mess up nobody's inconvenienced.