### PR TITLE
Add Service Alerts endpoint

### DIFF
--- a/CorvallisBus.Core/CorvallisBus.Core.csproj
+++ b/CorvallisBus.Core/CorvallisBus.Core.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.6.10" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
-
 </Project>

--- a/CorvallisBus.Core/Models/BusRoute.cs
+++ b/CorvallisBus.Core/Models/BusRoute.cs
@@ -25,8 +25,23 @@ namespace CorvallisBus.Core.Models
                 .ToList();
 
             Color = googleRoute[RouteNo].Color;
-            Url = googleRoute[RouteNo].Url;
+            Url = LookupUrl(RouteNo);
             Polyline = connectionzRoute.Polyline;
+        }
+
+        public static string LookupUrl(string routeName)
+        {
+            string suffix;
+            if (routeName == "NON")
+                suffix = "night-owl-north";
+            else if (routeName == "NOSE")
+                suffix = "night-owl-southeast";
+            else if (routeName == "NOSW")
+                suffix = "night-owl-southwest";
+            else
+                suffix = routeName.ToLower();
+
+            return "https://www.corvallisoregon.gov/cts/page/cts-route-" + suffix;
         }
 
         /// <summary>

--- a/CorvallisBus.Core/Models/GoogleTransit/GoogleRoute.cs
+++ b/CorvallisBus.Core/Models/GoogleTransit/GoogleRoute.cs
@@ -11,14 +11,12 @@ namespace CorvallisBus.Core.Models.GoogleTransit
         {
             Name = csv[0].Replace("\"", string.Empty); ;
             Color = csv[csv.Length - 2].Replace("\"", string.Empty);
-            Url = csv[csv.Length - 3].Replace("\"", string.Empty);
         }
 
-        public GoogleRoute(string Name, string Color, string Url)
+        public GoogleRoute(string Name, string Color)
         {
             this.Name = Name;
             this.Color = Color;
-            this.Url = Url;
         }
 
         /// <summary>
@@ -36,10 +34,5 @@ namespace CorvallisBus.Core.Models.GoogleTransit
         /// The color of the route as a hex string, e.g. "35EFA0".
         /// </summary>
         public string Color { get; private set; }
-
-        /// <summary>
-        /// The URL at the Corvallis website where more information about this route can be found.
-        /// </summary>
-        public string Url { get; private set; }
     }
 }

--- a/CorvallisBus.Core/Models/ServiceAlert.cs
+++ b/CorvallisBus.Core/Models/ServiceAlert.cs
@@ -11,6 +11,7 @@ namespace CorvallisBus.Core.Models
         /// Matches the format "yyyy-MM-dd'T'HH:mm:ssZ".
         /// </summary>
         public string PublishDate { get; }
+
         public string Link { get; }
 
         public ServiceAlert(string title, string publishDate, string link)

--- a/CorvallisBus.Core/Models/ServiceAlert.cs
+++ b/CorvallisBus.Core/Models/ServiceAlert.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace CorvallisBus.Core.Models
+{
+    public class ServiceAlert
+    {
+        public string Title { get; }
+
+        /// <summary>
+        /// The publish date of the service alert.
+        /// e.g. 2017-12-18T00:00:00-08:00
+        /// </summary>
+        public string PublishDate { get; }
+        public string Link { get; }
+
+        public ServiceAlert(string title, string publishDate, string link)
+        {
+            Title = title;
+            PublishDate = publishDate;
+            Link = link;
+        }
+    }
+}

--- a/CorvallisBus.Core/Models/ServiceAlert.cs
+++ b/CorvallisBus.Core/Models/ServiceAlert.cs
@@ -8,7 +8,7 @@ namespace CorvallisBus.Core.Models
 
         /// <summary>
         /// The publish date of the service alert.
-        /// e.g. 2017-12-18T00:00:00-08:00
+        /// Matches the format "yyyy-MM-dd'T'HH:mm:ssZ".
         /// </summary>
         public string PublishDate { get; }
         public string Link { get; }

--- a/CorvallisBus.Core/WebClients/GoogleTransitClient.cs
+++ b/CorvallisBus.Core/WebClients/GoogleTransitClient.cs
@@ -90,7 +90,7 @@ namespace CorvallisBus.Core.WebClients
 
             if(!routes.Any(x => x.Name == "C1R"))
             {
-                routes.Add(new GoogleRoute("C1R", "9F8E7D", "http://www.corvallisoregon.gov/index.aspx?page=1774"));
+                routes.Add(new GoogleRoute("C1R", "9F8E7D"));
             }
             return routes;
         }
@@ -122,7 +122,7 @@ namespace CorvallisBus.Core.WebClients
                 // skip format line
                 reader.ReadLine();
                 var lines = ReadLines(reader).ToList();
-                
+
                 var flatSchedule = lines.Select(line => line.Split(','))
                     .Where(line => !string.IsNullOrWhiteSpace(line[1]))
                     .Select(line => new
@@ -168,7 +168,7 @@ namespace CorvallisBus.Core.WebClients
                             StopSchedules = new List<GoogleStopSchedule>()
                         }
                     }, (result, line) => { result.daySchedule.StopSchedules.Add(line.stopSchedules); return result; }));
-                
+
                 // the aristocrats!
                 IList<GoogleRouteSchedule> routeSchedules = routeDaySchedules
                     .GroupBy(line => line.route)
@@ -195,7 +195,7 @@ namespace CorvallisBus.Core.WebClients
 
             using (var client = new WebClient())
             {
-                
+
                 var data = client.DownloadData(url);
                 return new MemoryStream(data);
             }

--- a/CorvallisBus.Core/WebClients/ITransitClient.cs
+++ b/CorvallisBus.Core/WebClients/ITransitClient.cs
@@ -8,11 +8,10 @@ using System.Threading.Tasks;
 
 namespace CorvallisBus.Core.WebClients
 {
-    using ServerBusSchedule = Dictionary<int, IEnumerable<BusStopRouteSchedule>>;
-
     public interface ITransitClient
     {
         BusSystemData LoadTransitData();
         Task<ConnexionzPlatformET> GetEta(int platformTag);
+        Task<List<ServiceAlert>> GetServiceAlerts();
     }
 }

--- a/CorvallisBus.Core/WebClients/ServiceAlertsClient.cs
+++ b/CorvallisBus.Core/WebClients/ServiceAlertsClient.cs
@@ -11,7 +11,7 @@ namespace CorvallisBus.Core.WebClients
     public static class ServiceAlertsClient
     {
         static readonly Uri FEED_URL = new Uri("https://www.corvallisoregon.gov/news?field_microsite_tid=581");
-        static HttpClient httpClient = new HttpClient();
+        static readonly HttpClient httpClient = new HttpClient();
         public static async Task<List<ServiceAlert>> GetServiceAlerts()
         {
             var responseStream = await httpClient.GetStreamAsync(FEED_URL);

--- a/CorvallisBus.Core/WebClients/ServiceAlertsClient.cs
+++ b/CorvallisBus.Core/WebClients/ServiceAlertsClient.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CorvallisBus.Core.Models;
+using HtmlAgilityPack;
+
+namespace CorvallisBus.Core.WebClients
+{
+    public static class ServiceAlertsClient
+    {
+        static readonly Uri FEED_URL = new Uri("https://www.corvallisoregon.gov/news?field_microsite_tid=581");
+        static HttpClient httpClient = new HttpClient();
+        public static async Task<List<ServiceAlert>> GetServiceAlerts()
+        {
+            var responseStream = await httpClient.GetStreamAsync(FEED_URL);
+            var htmlDocument = new HtmlDocument();
+            htmlDocument.Load(responseStream);
+
+            var alerts = htmlDocument.DocumentNode.SelectNodes("//tbody/tr")
+                .Select(row => ParseRow(row))
+                .ToList();
+            return alerts;
+        }
+
+        private static ServiceAlert ParseRow(HtmlNode row)
+        {
+            var anchor = row.Descendants("a").First();
+            var relativeLink = anchor.Attributes["href"].Value;
+            var link = new Uri(FEED_URL, relativeLink).ToString();
+            var title = anchor.InnerText;
+
+            var publishDate = row.Descendants("span")
+                .First(node => node.HasClass("date-display-single"))
+                .Attributes["content"]
+                .Value;
+
+            return new ServiceAlert(title, publishDate, link);
+        }
+    }
+}

--- a/CorvallisBus.Core/WebClients/TransitClient.cs
+++ b/CorvallisBus.Core/WebClients/TransitClient.cs
@@ -164,5 +164,7 @@ namespace CorvallisBus.Core.WebClients
 
             return result;
         }
+
+        public Task<List<ServiceAlert>> GetServiceAlerts() => ServiceAlertsClient.GetServiceAlerts();
     }
 }

--- a/CorvallisBus.Web/Controllers/TransitApiController.cs
+++ b/CorvallisBus.Web/Controllers/TransitApiController.cs
@@ -208,6 +208,12 @@ namespace CorvallisBus.Controllers
             }
         }
 
+        [HttpGet("service-alerts")]
+        public Task<List<ServiceAlert>> GetServiceAlerts()
+        {
+            return _client.GetServiceAlerts();
+        }
+
         /// <summary>
         /// Performs a first-time setup and import of static data.
         /// </summary>
@@ -228,7 +234,7 @@ namespace CorvallisBus.Controllers
             return Ok("Init job successful.");
         }
 
-        private void DataLoadJob()
+        void DataLoadJob()
         {
             var busSystemData = _client.LoadTransitData();
             

--- a/CorvallisBus.Web/Controllers/TransitApiController.cs
+++ b/CorvallisBus.Web/Controllers/TransitApiController.cs
@@ -214,6 +214,12 @@ namespace CorvallisBus.Controllers
             return _client.GetServiceAlerts();
         }
 
+        [HttpGet("service-alerts/html")]
+        public ActionResult GetServiceAlertsWebsite()
+        {
+            return Redirect("https://www.corvallisoregon.gov/news?field_microsite_tid=581");
+        }
+
         /// <summary>
         /// Performs a first-time setup and import of static data.
         /// </summary>
@@ -237,7 +243,7 @@ namespace CorvallisBus.Controllers
         void DataLoadJob()
         {
             var busSystemData = _client.LoadTransitData();
-            
+
             _repository.SetStaticData(busSystemData.StaticData);
             _repository.SetPlatformTags(busSystemData.PlatformIdToPlatformTag);
             _repository.SetSchedule(busSystemData.Schedule);

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The API documentation is also available via [PostMan Docs](https://documenter.ge
 - [/schedule/](#eta)
 - [/favorites](#favorites)
 - [/arrivals-summary/](#arrivals-summary)
+- [/service-alerts](#service-alerts)
+- [/service-alerts/html](#service-alerts/html)
 
 ### /static <a name="static"></a>
 
@@ -73,7 +75,7 @@ Output:
     }
     "stops":
     {
-      "10019": 
+      "10019":
       {
         "id": 10019,
         "name": "Benton Oaks RV Park",
@@ -102,7 +104,7 @@ Returns a JSON dictionary, where they keys are the supplied Stop IDs, and the va
 ```
 {
   "14244": {
-    
+
   },
   "13265": {
     "1": [6],
@@ -124,7 +126,7 @@ Since buses can run behind by 15 minutes or more, or have runs cancelled outrigh
 
 For instance, in the case of a bus running late, scheduled arrival times can be shown only at least 20 minutes in advance. If they instead were shown only at least 30 minutes in advance, there would be gaps in time where a bus's likely arrival wouldn't be apparent to the user. In other words, the API allows the schedule a 10-minute grace period to "pass" as an estimate, but when the city starts putting out an estimate for that same bus's arrival, the scheduled time gets replaced by the estimated time.
 
-Input: 
+Input:
    - **Required** one or more stop IDs
 
 Output:
@@ -136,7 +138,7 @@ Output:
 {
   "14244": {
     "1": [
-      
+
     ],
     "2": [
       {
@@ -145,12 +147,12 @@ Output:
 	  }
     ],
     "4": [
-      
+
     ]
   },
   "13265": {
     "1": [
-      
+
     ],
     "2": [
       {
@@ -159,7 +161,7 @@ Output:
 	  }
     ],
     "3": [
-      
+
     ],
     "5": [
       { "minutesFromNow": 35, "isEstimate": false },
@@ -171,13 +173,13 @@ Output:
       { "minutesFromNow": 12, "isEstimate": true }
     ],
     "8": [
-      
+
     ]
   }
 }
 ```
 ### /favorites <a name="favorites"></a>
-   
+
 Sample URL: https://corvallisb.us/api/favorites?stops=11776,10308&location=44.5645659,-123.2620435
 
 Input:
@@ -188,7 +190,7 @@ One or more of the following query parameters are required.
 Output:
 
    A JSON array of stop information for "favorite stops" features. This allows a developer to easily create a widget to show the user's favorite stops. It shows arrivals summary information for the nearest 2 routes that will arrive at each favorite stop. If the user consents to provide a location, it will determine the stop's distance from the user and sort ascending by this quantity. The widget merely needs to wake up, download less than 1 KB of data, and display it.
-   
+
 ```
 [
   {
@@ -231,7 +233,7 @@ Output:
 ```
 
 ### /arrivals-summary/ <a name="arrivals-summary"></a>
-   
+
 Sample URL: https://corvallisb.us/api/arrivals-summary/10308,14237
 
 Input:
@@ -241,50 +243,84 @@ Output:
    A dictionary where the keys are stop IDs and the values are a list of nice, user-friendly descriptions of the arrival times for each route at that stop, sorted by descending arrival time. The server tries to determine if the route arrives at the stop "pretty much" hourly or half-hourly. Most routes arrive hourly, with a 10-minute break in the middle of the day. Thus if all the scheduled times left in the day are between 50-70 minutes from each other, it's considered to be an hourly schedule. Similarly with all being 20-40 minutes apart to be considered half-hourly.
 
 ```
-{  
-  "10308":[  
-    {  
+{
+  "10308":[
+    {
       "routeName":"2",
       "arrivalsSummary":"1 minute, then 07:48 PM",
       "scheduleSummary":""
     },
-    {  
+    {
       "routeName":"1",
       "arrivalsSummary":"10 minutes",
       "scheduleSummary":""
     },
-    {  
+    {
       "routeName":"5",
       "arrivalsSummary":"11 minutes, then 07:48 PM",
       "scheduleSummary":"Last arrival at 09:18 PM"
     },
     ...,
-    {  
+    {
       "routeName":"8",
       "arrivalsSummary":"No arrivals!",
       "scheduleSummary":""
     },
-    {  
+    {
       "routeName":"C1",
       "arrivalsSummary":"No arrivals!",
       "scheduleSummary":""
     },
-    {  
+    {
       "routeName":"C3",
       "arrivalsSummary":"No arrivals!",
       "scheduleSummary":""
     },
-    {  
+    {
       "routeName":"CVA",
       "arrivalsSummary":"No arrivals!",
       "scheduleSummary":""
     }
   ],
-  "14237":[  
-    {  
+  "14237":[
+    {
       "routeName":"6",
       "arrivalsSummary":"17 minutes, then 07:54 PM",
       "scheduleSummary":"Last arrival at 08:24 PM"
     }
   ]
 }
+```
+
+### /service-alerts/ <a name="service-alerts"></a>
+
+Provides information on CTS service alerts.
+
+Sample URL: https://corvallisb.us/api/service-alerts
+
+Output: A JSON list of objects containing "title", "publishDate", and "link", which is a URL to a webpage with more details on the service alert.
+```
+[
+  {
+    "title": "Holiday Service",
+    "publishDate": "2017-12-18T00:00:00-08:00",
+    "link": "https://www.corvallisoregon.gov/cts/page/holiday-service"
+  },
+  {
+    "title": "Philomath Connection Offers Saturday Service",
+    "publishDate": "2017-12-12T00:00:00-08:00",
+    "link": "https://www.corvallisoregon.gov/cts/page/philomath-connection-offers-saturday-service"
+  },
+  {
+    "title": "Upcoming Schedule for CTS and Night Owl",
+    "publishDate": "2017-11-29T00:00:00-08:00",
+    "link": "https://www.corvallisoregon.gov/cts/page/upcoming-schedule-cts-and-night-owl"
+  }
+]
+```
+
+### /service-alerts/html <a name="service-alerts/html"></a>
+
+Redirects to the current location of the Corvallis Transit Service Alerts website.
+
+Sample URL: https://corvallisb.us/api/service-alerts/html


### PR DESCRIPTION
Corvallis Transit changed the way they publish service alerts. This will make it so future breaking changes to the publishing of Service Alerts will just require a server-side change, not modification of the clients.

