### PR TITLE
Fix ordering issue in Google data for BB_N

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.1.2
+dotnet: 2.1.403
 script:
   - dotnet build
   - dotnet test CorvallisBus.Test

--- a/CorvallisBus.Core/WebClients/GoogleTransitClient.cs
+++ b/CorvallisBus.Core/WebClients/GoogleTransitClient.cs
@@ -129,7 +129,7 @@ namespace CorvallisBus.Core.WebClients
                     {
                         route = s_routePattern.Match(line[0]).Groups[1].Value,
                         stop = line[3],
-                        order = line[4],
+                        order = int.Parse(line[4]),
                         days = DaysOfWeekUtils.GetDaysOfWeek(line[0]),
                         time = ToTimeSpan(line[1].Replace("\"", string.Empty))
                     });
@@ -144,6 +144,7 @@ namespace CorvallisBus.Core.WebClients
                         order = line.order,
                         days = line.days
                     })
+                    .OrderBy(line => line.Key.order)
                     .Select(grouping => grouping.Aggregate(new List<TimeSpan>(),
                         (times, time) => { times.Add(time.time); return times; },
                         times => new

--- a/CorvallisBus.Test/CorvallisBus.Test.csproj
+++ b/CorvallisBus.Test/CorvallisBus.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CorvallisBus.Web/CorvallisBus.Web.csproj
+++ b/CorvallisBus.Web/CorvallisBus.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CorvallisBus.Web/CorvallisBus.Web.csproj
+++ b/CorvallisBus.Web/CorvallisBus.Web.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We weren't respecting the `order` attribute in the CSV before. The data was almost all ordered as we needed except for BB_N (Night Owl North).

No tests added, but running this validation method on the Google schedule on the commit before acb4f0c reveals the issue in the schedule order:

```cs
private static void ValidateGoogleSchedule(List<GoogleRouteSchedule> routeSchedules)
{
    foreach (GoogleRouteSchedule routeSchedule in routeSchedules)
    {
        foreach (GoogleDaySchedule routeDaySchedule in routeSchedule.Days)
        {
            var stopSchedules = routeDaySchedule.StopSchedules;
            var pairs = stopSchedules.Take(stopSchedules.Count - 1).Zip(stopSchedules.Skip(1), (fst, snd) => (fst, snd));
            foreach (var (fst, snd) in pairs)
            {
                Debug.Assert(fst.Times.Count == snd.Times.Count);
                for (var i = 0; i < fst.Times.Count; i++)
                {
                    if (fst.Times[0] > snd.Times[0])
                    {
                        Console.WriteLine($"{routeSchedule.RouteNo}: {fst.Name} at {fst.Times[i]} occurs after {snd.Name} at {snd.Times[i]}");
                    }
                }
            }
        }
    }
}
```
output:
```
BB_N: "ConiferBlvd_N_ParkCir" at 21:25:00 occurs after "MonroeAve_S_5thSt" at 20:45:00
BB_N: "ConiferBlvd_N_ParkCir" at 22:25:00 occurs after "MonroeAve_S_5thSt" at 21:45:00
BB_N: "ConiferBlvd_N_ParkCir" at 23:25:00 occurs after "MonroeAve_S_5thSt" at 22:45:00
BB_N: "ConiferBlvd_N_ParkCir" at 1.00:25:00 occurs after "MonroeAve_S_5thSt" at 23:45:00
BB_N: "ConiferBlvd_N_ParkCir" at 1.01:25:00 occurs after "MonroeAve_S_5thSt" at 1.00:45:00
BB_N: "ConiferBlvd_N_ParkCir" at 1.02:25:00 occurs after "MonroeAve_S_5thSt" at 1.01:45:00
```