### PR TITLE
Workaround for service alerts not fetching in Azure

### DIFF
--- a/CorvallisBus.Core/WebClients/ServiceAlertsClient.cs
+++ b/CorvallisBus.Core/WebClients/ServiceAlertsClient.cs
@@ -14,6 +14,7 @@ namespace CorvallisBus.Core.WebClients
         static readonly HttpClient httpClient = new HttpClient();
         public static async Task<List<ServiceAlert>> GetServiceAlerts()
         {
+#if false
             var responseStream = await httpClient.GetStreamAsync(FEED_URL);
             var htmlDocument = new HtmlDocument();
             htmlDocument.Load(responseStream);
@@ -22,6 +23,11 @@ namespace CorvallisBus.Core.WebClients
                 .Select(row => ParseRow(row))
                 .ToList();
             return alerts;
+#endif
+            return await Task.FromResult(new List<ServiceAlert>()
+            {
+                new ServiceAlert("Tap to view service alerts", "2018-11-4T00:00:00-07:00", "https://www.corvallisoregon.gov/news?field_microsite_tid=581")
+            });
         }
 
         private static ServiceAlert ParseRow(HtmlNode row)


### PR DESCRIPTION
The api/service-alerts endpoint used to work by scraping the HTML served up by the city. It still works locally but stopped working in Azure at some point. Requests to Connexionz are still working fine so I'm not sure what changed.

For now I published a workaround which just returns a dummy service alert that links to the website so the user can go there directly.